### PR TITLE
ast_objects.json: add usercontext to trunks. nethesis/dev#5202

### DIFF
--- a/Nethcti3.class.php
+++ b/Nethcti3.class.php
@@ -57,6 +57,7 @@ class Nethcti3 implements \BMO
                     "tech"=>$trunk["tech"],
                     "trunkid"=>$trunk["trunkid"],
                     "name"=>$trunk["name"],
+                    "usercontext"=>$trunk["usercontext"],
                     "maxchans"=>$trunk["maxchans"]
                 );
             }


### PR DESCRIPTION
example of modified ast_objects.json:

```
{
    "trunks": {
        "vmalep_nethvoice": {
            "tech": "iax",
            "trunkid": "1",
            "name": "vmalep_nethvoice",
            "usercontext": "nethvoice-vmalep",        // <--------- the added data
            "maxchans": ""
        },
        "...
```