### PR TITLE
Add channel open for call forward

### DIFF
--- a/agi-bin/offhour.php
+++ b/agi-bin/offhour.php
@@ -114,6 +114,8 @@ switch ($res['action']) {
         //Call forward
         if ($res['param'] != '') {
             @$agi->verbose("[offhour] call forward to {$res['param']}",4);
+            $agi->answer();
+            $agi->stream_file('silence/1');
             # Dial Local/$param...
             $agi->exec_dial("Local",$res['param']."@from-internal");
         } else {


### PR DESCRIPTION
The channel audio must be open before forwarding the call otherwise the call will be silent.
At least one rtp packet must be sent, for this reason, a one-second silence file playback has been added.