### PR TITLE
Include paging and bosseretary context to cti profile contexts

### DIFF
--- a/functions.inc.php
+++ b/functions.inc.php
@@ -163,6 +163,11 @@ function nethcti3_get_config_late($engine) {
                 }
             }
 
+            // Add NethHotel services context
+            if (function_exists('nethhotel_get_config')) {
+                $includes[] = 'hotel-services';
+            }
+
             if (!empty($includes)) {
                 foreach (getCTIPermissionProfiles() as $profile) {
                     foreach ($includes as $include) {


### PR DESCRIPTION
Paging and bossecretary context are included to dialplan only when changes are applied. This PR add them to CTI profile contexts. That means that they are added at runtime and it won't possible to disable them.