### PR TITLE
Use transferor's extension number when doing an attended transfer

### DIFF
--- a/functions.inc.php
+++ b/functions.inc.php
@@ -103,7 +103,6 @@ function nethcti3_get_config($engine) {
                     $ext->splice('app-dnd-toggle', $codes['dnd_toggle'], "hook_off", new ext_agi('send_notify.php,${AMPUSER}'),'notify',1);
                 }
             }
-
         break;
     }
 }
@@ -157,6 +156,10 @@ function nethcti3_get_config_late($engine) {
 
                 $ext->replace('app-all-queue-pause-toggle', 's', '4', new ext_agi('queue_devstate.agi,toggle-pause-all,${QUEUEUSER}'));
                 $ext->splice('app-all-queue-pause-toggle', 's', 'start', new ext_setvar('QUEUEUSER', '${IF($[${LEN(${DB(AMPUSER/${AMPUSER}/accountcode)})}>0]?${DB(AMPUSER/${AMPUSER}/accountcode)}:${AMPUSER})}'),'mainext',3);
+            }
+            if (!isset($amp_conf['ATX_CID_OVERRIDE']) || $amp_conf['ATX_CID_OVERRIDE'] == 1) {
+                $ext->splice('macro-dial-one','s','dial', new ext_execif('$["${DB(AMPUSER/${ARG3}/cidname)}" != "" && "${CHANNEL:0:5}"="Local" && "${DB(AMPUSER/${CALLERID(num)}/cidname)}" = ""]', 'Set', 'CALLERID(num)=${DB(AMPUSER/${FROMEXTEN}/cidnum)}'),'',-1);
+                $ext->splice('macro-dial-one','s','dial', new ext_execif('$["${DB(AMPUSER/${CALLERID(num)}/cidname)}" != ""]', 'Set', 'CALLERID(name)=${DB(AMPUSER/${CALLERID(num)}/cidname)}'),'',-1);
             }
         break;
     }

--- a/install.php
+++ b/install.php
@@ -4,6 +4,22 @@ if (!defined('FREEPBX_IS_AUTH')) { die('No direct script access allowed'); }
 global $db;
 global $amp_conf;
 
+$freepbx_conf =& freepbx_conf::create();
+$set=[];
+$set['value'] = true;
+$set['defaultval'] =& $set['value'];
+$set['readonly'] = 0;
+$set['hidden'] = 0;
+$set['level'] = 0;
+$set['module'] = '';
+$set['category'] = 'Dialplan and Operational';
+$set['emptyok'] = 1;
+$set['sortorder'] = 0;
+$set['name'] = 'Attended Transfer Caller ID Override';
+$set['description'] = 'Use transferor\'s extension number when doing an attended transfer of an external outgoing call';
+$set['type'] = CONF_TYPE_BOOL;
+$freepbx_conf->define_conf_setting('ATX_CID_OVERRIDE',$set,true);
+
 $sql='
     CREATE TABLE IF NOT EXISTS `offhour` (
       `id` int(11) NOT NULL auto_increment,

--- a/module.xml
+++ b/module.xml
@@ -2,7 +2,7 @@
   <rawname>nethcti3</rawname>
   <repo>unsupported</repo>
   <name>NethCTI 3 Configuration Module</name>
-  <version>1.4.29</version>
+  <version>1.4.31</version>
   <category>Applications</category>
   <Publisher>Nethesis</Publisher>
   <info></info>


### PR DESCRIPTION
Use transferor's extension number when doing an attended transfer of an external outgoing call
https://github.com/nethesis/dev/issues/6185