### PR TITLE
Fix offhours

### DIFF
--- a/functions.inc.php
+++ b/functions.inc.php
@@ -214,28 +214,28 @@ function nethcti3_get_config_late($engine) {
                 $ext->splice("from-queue-exten-only", '_'.str_repeat('X',$row['len']), 'checkrecord', new ext_set('CDR(ccompany)','${REAL_CCOMPANY}'),"ccompany");
             }
         }
-                    /*Off-Hour*/
-                    $routes = FreePBX::Core()->getAllDIDs();
-                    foreach ($routes as $did) {
-                        /*add off-hour agi for each inbound routes*/
-                        if($did['extension'] && $did['cidnum'])
-                            $exten = $did['extension']."/".$did['cidnum'];
-                        else if (!$did['extension'] && $did['cidnum'])
-                            $exten = "s/".$did['cidnum'];
-                        else if ($did['extension'] && !$did['cidnum'])
-                            $exten = $did['extension'];
-                        else if (!$did['extension'] && !$did['cidnum'])
-                            $exten = "s";
-        
-                        if (($did['cidnum'] != '' && $did['extension'] != '') || ($did['cidnum'] == '' && $did['extension'] == '')) {
-                            $pricid = true;
-                        } else {
-                            $pricid = false;
-                        }
-                        $context = ($pricid) ? "ext-did-0001":"ext-did-0002";
-                        $ext->splice($context, $exten, "did-cid-hook", new ext_userevent('CallIn', 'value: ${FROM_DID}'),'cti-event',2);
-                        $ext->splice($context, $exten, "did-cid-hook", new ext_agi('offhour.php,'.$did['cidnum'].','.$did['extension']),'offhour',3);
-                    }
+        /*Off-Hour*/
+        $routes = FreePBX::Core()->getAllDIDs();
+        foreach ($routes as $did) {
+            /*add off-hour agi for each inbound routes*/
+            if($did['extension'] && $did['cidnum'])
+                $exten = $did['extension']."/".$did['cidnum'];
+            else if (!$did['extension'] && $did['cidnum'])
+                $exten = "s/".$did['cidnum'];
+            else if ($did['extension'] && !$did['cidnum'])
+                $exten = $did['extension'];
+            else if (!$did['extension'] && !$did['cidnum'])
+                $exten = "s";
+
+            if (($did['cidnum'] != '' && $did['extension'] != '') || ($did['cidnum'] == '' && $did['extension'] == '')) {
+                $pricid = true;
+            } else {
+                $pricid = false;
+            }
+            $context = ($pricid) ? "ext-did-0001":"ext-did-0002";
+            $ext->splice($context, $exten, "did-cid-hook", new ext_userevent('CallIn', 'value: ${FROM_DID}'),'cti-event',2);
+            $ext->splice($context, $exten, "did-cid-hook", new ext_agi('offhour.php,'.$did['cidnum'].','.$did['extension']),'offhour',3);            
+        }
         break;
     }
 

--- a/functions.inc.php
+++ b/functions.inc.php
@@ -100,28 +100,6 @@ function nethcti3_get_config_late($engine) {
     global $db;
     switch($engine) {
         case "asterisk":
-            /*Off-Hour*/
-            $routes = FreePBX::Core()->getAllDIDs();
-            foreach ($routes as $did) {
-                /*add off-hour agi for each inbound routes*/
-                if($did['extension'] && $did['cidnum'])
-                    $exten = $did['extension']."/".$did['cidnum'];
-                else if (!$did['extension'] && $did['cidnum'])
-                    $exten = "s/".$did['cidnum'];
-                else if ($did['extension'] && !$did['cidnum'])
-                    $exten = $did['extension'];
-                else if (!$did['extension'] && !$did['cidnum'])
-                    $exten = "s";
-
-                if (($did['cidnum'] != '' && $did['extension'] != '') || ($did['cidnum'] == '' && $did['extension'] == '')) {
-                    $pricid = true;
-                } else {
-                    $pricid = false;
-                }
-                $context = ($pricid) ? "ext-did-0001":"ext-did-0002";
-                $ext->splice($context, $exten, "did-cid-hook", new ext_userevent('CallIn', 'value: ${FROM_DID}'),'cti-event',2);
-                $ext->splice($context, $exten, "did-cid-hook", new ext_agi('offhour.php,'.$did['cidnum'].','.$did['extension']),'offhour',3);
-            }
             /* Add wakeup for App*/
             $ext->splice('macro-dial-one', 's','setexttocall', new ext_agi('/var/lib/asterisk/agi-bin/app_wakeup.php'));
             $ext->splice('macro-dial', 's', 'dial', new ext_agi('/var/lib/asterisk/agi-bin/app_wakeup.php'));
@@ -236,6 +214,28 @@ function nethcti3_get_config_late($engine) {
                 $ext->splice("from-queue-exten-only", '_'.str_repeat('X',$row['len']), 'checkrecord', new ext_set('CDR(ccompany)','${REAL_CCOMPANY}'),"ccompany");
             }
         }
+                    /*Off-Hour*/
+                    $routes = FreePBX::Core()->getAllDIDs();
+                    foreach ($routes as $did) {
+                        /*add off-hour agi for each inbound routes*/
+                        if($did['extension'] && $did['cidnum'])
+                            $exten = $did['extension']."/".$did['cidnum'];
+                        else if (!$did['extension'] && $did['cidnum'])
+                            $exten = "s/".$did['cidnum'];
+                        else if ($did['extension'] && !$did['cidnum'])
+                            $exten = $did['extension'];
+                        else if (!$did['extension'] && !$did['cidnum'])
+                            $exten = "s";
+        
+                        if (($did['cidnum'] != '' && $did['extension'] != '') || ($did['cidnum'] == '' && $did['extension'] == '')) {
+                            $pricid = true;
+                        } else {
+                            $pricid = false;
+                        }
+                        $context = ($pricid) ? "ext-did-0001":"ext-did-0002";
+                        $ext->splice($context, $exten, "did-cid-hook", new ext_userevent('CallIn', 'value: ${FROM_DID}'),'cti-event',2);
+                        $ext->splice($context, $exten, "did-cid-hook", new ext_agi('offhour.php,'.$did['cidnum'].','.$did['extension']),'offhour',3);
+                    }
         break;
     }
 


### PR DESCRIPTION
After moving lookup dialplan hooks, lookup tags were no more added before offhour. Moving offour after lookup make sure that the dialplan rows are added after lookup

https://github.com/nethesis/ns8-nethvoice/issues/116